### PR TITLE
Fix Swapped NIDs for GetParameterDirection and GetParameterVariability

### DIFF
--- a/nids/SceShaccCg.yml
+++ b/nids/SceShaccCg.yml
@@ -18,14 +18,14 @@ modules:
           sceShaccCgGetParameterByName: 0x6FB40CA9
           sceShaccCgGetParameterClass: 0xDF3DDCFD
           sceShaccCgGetParameterColumns: 0x7BC25091
-          sceShaccCgGetParameterDirection: 0xF4BAB902
+          sceShaccCgGetParameterDirection: 0xDAD4AAE4
           sceShaccCgGetParameterMemoryLayout: 0xEF8D59D6
           sceShaccCgGetParameterName: 0x4595A388
           sceShaccCgGetParameterResourceIndex: 0x6BB58825
           sceShaccCgGetParameterRows: 0x2654E73A
           sceShaccCgGetParameterSemantic: 0xA7930FF6
           sceShaccCgGetParameterUserType: 0x152971B1
-          sceShaccCgGetParameterVariability: 0xDAD4AAE4
+          sceShaccCgGetParameterVariability: 0xF4BAB902
           sceShaccCgGetParameterVectorWidth: 0x0205DE96
           sceShaccCgGetRowParameter: 0x07DDFC78
           sceShaccCgGetSamplerQueryFormatPrecision: 0xA067C481


### PR DESCRIPTION
Turns out these looked very similar in comparison but the NIDs point to the wrong function. This fixes sceShaccCgGetParameterVariability returning Parameter Direction and vice versa